### PR TITLE
Switch bullet base velocity to local frame

### DIFF
--- a/go2_simulation/abstract_wrapper.py
+++ b/go2_simulation/abstract_wrapper.py
@@ -8,4 +8,8 @@ FeetForces = List[float]
 
 class AbstractSimulatorWrapper:
     def step(tau: Torques) -> Tuple[Configuration, Velocities, Accelerations, FeetForces]:
+        """
+        Take as input torque commands for each joint and ouptut the robot new state.
+        Note: the base velocity and acceleration (the first 6 values of the Velocities and Accelerations vector) are expressed in the local frame of the robot base.
+        """
         raise NotImplementedError


### PR DESCRIPTION
The step function of the simulator should output base velocity and acceleration in local frame. 

Minor changes introduced in this PR:
- the starting height of the robot in Bullet is increased to avoid clipping through the ground when the MPC is launched.
- The base offset translation is taken care of in the computation of linear velocity in Bullet.